### PR TITLE
remove double checking for validThrough for Contentful job posts

### DIFF
--- a/app/careers/positions-section.tsx
+++ b/app/careers/positions-section.tsx
@@ -1,5 +1,4 @@
 import { fieldsType } from "@/lib/contentfulApi";
-import { dateInPast } from "@/lib/utils";
 
 const PositionsList = ({
   posts,
@@ -11,9 +10,6 @@ const PositionsList = ({
       <div role="list" className="w-dyn-items">
         {posts
           .map(({ fields }) => {
-            if (dateInPast(new Date(fields.validThrough ?? new Date()))) {
-              return;
-            }
             return (
               <div key={fields.slug} role="listitem" className="w-dyn-item">
                 <a

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,10 +13,3 @@ export function getPathnameFromState(state: ResolvingMetadata): string {
 
   return url.pathname;
 }
-
-export function dateInPast(firstDate: Date, secondDate = new Date()) {
-  return (
-    new Date(firstDate).setHours(0, 0, 0, 0) <=
-    new Date(secondDate).setHours(0, 0, 0, 0)
-  );
-}


### PR DESCRIPTION
/careers page: while query Contentful for job posts, it already filter by validThrough >= today.

So we can safely remove the double checking here.